### PR TITLE
Update NuSpec and Correct Private Dependency

### DIFF
--- a/TelesignEnterprise/TelesignEnterprise.csproj
+++ b/TelesignEnterprise/TelesignEnterprise.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="Telesign, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Telesign.2.2.1\lib\net452\Telesign.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TelesignEnterprise/telesignenterprise.nuspec
+++ b/TelesignEnterprise/telesignenterprise.nuspec
@@ -11,6 +11,10 @@
     <iconUrl>https://raw.github.com/TeleSign/csharp_telesign/master/nuget_icon.jpg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The TeleSign C# SDK lets you easily integrate with our REST API.</description>
+    <dependencies>
+      <dependency id="Telesign" version="2.2.1" />
+      <dependency id="Newtonsoft.Json" version="10.0.2" />
+    </dependencies>
     <releaseNotes><![CDATA[
             For full release notes see https://github.com/TeleSign/csharp_telesign_enterprise/blob/master/RELEASE.md
             ]]></releaseNotes>


### PR DESCRIPTION
When initially pulling in this project, we discovered that it doesn't compile out of the box.  Because of the `<Private>True</Private>` bit.  With regards to the Nuspec other dependencies are required and they should be listed in the metadata in the Nuspec.

Additionally, this made the project able to be built and can be loaded into a private Nuget repository.  With these changes, we can hook into your repository and update our clients every time y'all update your package.
![image](https://user-images.githubusercontent.com/828489/62225082-62b7b000-b37d-11e9-8263-e358a079c7ca.png)
_Screenshot from our private Nuget repository_

Let me know if you have any questions!